### PR TITLE
fix incorrect format for user-properties in request

### DIFF
--- a/src/Dto/Common/UserProperties.php
+++ b/src/Dto/Common/UserProperties.php
@@ -39,9 +39,12 @@ class UserProperties implements ExportableInterface
      */
     public function export(): array
     {
-        return array_map(function ($userProperty) {
-            return $userProperty->export();
-        }, $this->getUserPropertiesList());
+        return array_reduce($this->getUserPropertiesList(), function ($last, UserProperty $userProperty) {
+            $last[$userProperty->getName()] = [
+                'value' => $userProperty->getValue(),
+            ];
+            return $last;
+        }, []);
     }
 
     /**

--- a/src/Dto/Common/UserProperties.php
+++ b/src/Dto/Common/UserProperties.php
@@ -40,10 +40,7 @@ class UserProperties implements ExportableInterface
     public function export(): array
     {
         return array_reduce($this->getUserPropertiesList(), function ($last, UserProperty $userProperty) {
-            $last[$userProperty->getName()] = [
-                'value' => $userProperty->getValue(),
-            ];
-            return $last;
+            return array_merge($last, $userProperty->export());
         }, []);
     }
 

--- a/tests/Ga4/MeasurementProtocol/Dto/Common/UserPropertiesTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Common/UserPropertiesTest.php
@@ -71,17 +71,17 @@ class UserPropertiesTest extends BaseTestCase
         $this->userProperties->setUserPropertiesList($setUserProperties);
 
         $this->assertEquals([
-            [$setUserProperties[0]->getName() => [
+            $setUserProperties[0]->getName() => [
                 'value' => $setUserProperties[0]->getValue()
-            ]],
-            [$setUserProperties[1]->getName() => [
+            ],
+            $setUserProperties[1]->getName() => [
                 'value' => $setUserProperties[1]->getValue()
-            ]],
-            [$setUserProperties[2]->getName() => [
+            ],
+            $setUserProperties[2]->getName() => [
                 'value' => $setUserProperties[2]->getValue()
-            ]]
+            ],
         ], $this->userProperties->export());
-    }
+}
 
     protected function setUp(): void
     {


### PR DESCRIPTION
ref:
https://developers.google.com/analytics/devguides/collection/protocol/ga4/user-properties?client_type=gtag#example_usage

```
fetch(`https://www.google-analytics.com/mp/collect${queryParams}`, {
    method: "POST",
    body: JSON.stringify({
      "client_id": clientId,
      "user_properties": {
        "customer_tier": {
          "value": customerTier
        }
      },
      "events": JSON.parse(events)
    })
  });
```