### PR TITLE
Adding add_to_wishlist event

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ At the moment, the library contains the defined structures of the following even
 | add_payment_info | AddPaymentInfoEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#add_payment_info)
 | add_shipping_info | AddShippingInfoEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#add_shipping_info)
 | add_to_cart | AddToCartEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#add_to_cart)
+| add_to_wishlist | AddToWishlistEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=fr&client_type=gtag#add_to_wishlist)
 | begin_checkout | BeginCheckoutEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#begin_checkout)
 | login | LoginEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#login)
 | purchase | PurchaseEvent | [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#purchase)

--- a/src/Dto/Event/AddToWishlistEvent.php
+++ b/src/Dto/Event/AddToWishlistEvent.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * User: Alexis POUPELIN (AlexisPPLIN)
+ * Date: 06.11.2023
+ * Time: 17:00
+ */
+
+namespace Br33f\Ga4\MeasurementProtocol\Dto\Event;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Parameter\AbstractParameter;
+use Br33f\Ga4\MeasurementProtocol\Enum\ErrorCode;
+use Br33f\Ga4\MeasurementProtocol\Exception\ValidationException;
+
+/**
+ * Class AddToWishlistEvent
+ * @package Br33f\Ga4\MeasurementProtocol\Dto\Event
+ * @method string getCurrency()
+ * @method AddToWishlistEvent setCurrency(string $currency)
+ * @method float getValue()
+ * @method AddToWishlistEvent setValue(float $value)
+ */
+class AddToWishlistEvent extends ItemBaseEvent
+{
+    private $eventName = 'add_to_wishlist';
+
+    /**
+     * AddToWishlistEvent constructor.
+     * @param AbstractParameter[] $paramList
+     */
+    public function __construct(array $paramList = [])
+    {
+        parent::__construct($this->eventName, $paramList);
+    }
+
+    public function validate()
+    {
+        parent::validate();
+
+        if (!empty($this->getValue())) {
+            if (empty($this->getCurrency())) {
+                throw new ValidationException('Field "currency" is required if "value" is set', ErrorCode::VALIDATION_FIELD_REQUIRED, 'currency');
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Ga4/MeasurementProtocol/Dto/Event/AddToWishlistEventTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Event/AddToWishlistEventTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * User: Alexis POUPELIN (AlexisPPLIN)
+ * Date: 22.11.2023
+ * Time: 15:00
+ */
+
+namespace Tests\Ga4\MeasurementProtocol\Dto\Event;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Event\AddToWishlistEvent;
+use Br33f\Ga4\MeasurementProtocol\Exception\ValidationException;
+use Tests\Common\BaseTestCase;
+
+class AddToWishlisEventTest extends BaseTestCase
+{
+    /**
+     * @var AddToWishlistEvent
+     */
+    protected $event;
+
+    public function testDefaultConstructor()
+    {
+        $constructedEvent = new AddToWishlistEvent();
+
+        $this->assertNotNull($constructedEvent);
+        $this->assertEquals('add_to_wishlist', $constructedEvent->getName());
+    }
+
+    public function testValidateSuccess()
+    {
+        $this->event->setValue($this->faker->randomFloat(2, 10, 3000));
+        $this->event->setCurrency($this->faker->currencyCode);
+
+        $this->assertTrue($this->event->validate());
+    }
+
+    public function testValidateFail()
+    {
+        $this->event->setValue($this->faker->randomFloat(2, 10, 3000));
+
+        $this->expectException(ValidationException::class);
+        $this->event->validate();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->event = new AddToWishlistEvent();
+    }
+}


### PR DESCRIPTION
Hi !

I've added support for `add_to_wishlist` event.
It's a simple duplication of AddToCartEvent class with few naming changes.

- Google Developers reference for `add_to_wishlist` event :
https://developers.google.com/analytics/devguides/collection/ga4/reference/events?hl=fr&client_type=gtag#add_to_wishlist

Have a nice day  / night !