### PR TITLE
Avoid calling getContents() on response stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Latest Stable Version](https://poser.pugx.org/br33f/php-ga4-mp/v/stable.png)](https://packagist.org/packages/br33f/php-ga4-mp)
 [![Total Downloads](https://poser.pugx.org/br33f/php-ga4-mp/downloads.png)](https://packagist.org/packages/br33f/php-ga4-mp)
 ## Overview
-This is a PHP Library facilitating the use of Google Analytics 4 (GA4) Measurement Protocol. Measurement Protocol allows developers to send events directly from server-side PHP to Google Analytics. 
+
+This is a PHP Library facilitating the use of Google Analytics 4 (GA4) Measurement Protocol. Measurement Protocol allows
+developers to send events directly from server-side PHP to Google Analytics.
 
 Full documentation is available here:
 https://developers.google.com/analytics/devguides/collection/protocol/ga4
@@ -65,8 +67,8 @@ $viewedItem
     ->setItemName('ITEM_NAME')
     ->setPrice(25.55)
     ->setQuantity(2);
-    
-// Add this item to viewItemEventData   
+
+// Add this item to viewItemEventData
 $viewItemEventData->addItem($viewedItem);
 
 // Add event to base request (you can add up to 25 events to single request)
@@ -105,7 +107,7 @@ $purchasedItem1
     ->setItemName('FIRST_ITEM_NAME')
     ->setPrice(100.00)
     ->setQuantity(2);
-    
+
 // Add this item to purchaseEventData
 $purchaseEventData->addItem($purchasedItem1);
 
@@ -158,7 +160,7 @@ use Br33f\Ga4\MeasurementProtocol\Dto\Event\BaseEvent;
 // ...
 
 // Create Base Event Data (for example: 'share' event - https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events#share)
-$eventName = 'share'; 
+$eventName = 'share';
 $anyEventData = new BaseEvent($eventName);
 $anyEventData
     ->setMethod('Twitter')
@@ -227,13 +229,62 @@ $addToCartEventData->addItem(new ItemParameter([
 $baseRequest->addEvent($addToCartEventData);
 
 // Instead of sending data to production Measurement Protocol endpoint
-// $ga4Service->send($baseRequest); 
+// $ga4Service->send($baseRequest);
 // Send data to validation endpoint, which responds with status cude and validation messages.
 $debugResponse = $ga4Service->sendDebug($baseRequest);
 
 // Now debug response contains status code, and validation messages if request is invalid
-var_dump($debugResponse->getStatusCode()); 
+var_dump($debugResponse->getStatusCode());
 var_dump($debugResponse->getValidationMessages());
+
+```
+
+## Get response as stream
+
+It is possible to get response as stream. This is useful when you want to process response further and you don't want
+the stream to be consumed in BaseResponse.
+
+Method `sendStream($request)` returns `StreamResponse` object, which is hydrated with response data such
+as: `status_code` (just as usual) and `body` which is a stream resource.
+
+### Example:
+
+```php
+use Br33f\Ga4\MeasurementProtocol\Service;
+use Br33f\Ga4\MeasurementProtocol\Dto\Request\BaseRequest;
+use Br33f\Ga4\MeasurementProtocol\Dto\Event\AddToCartEvent;
+use Br33f\Ga4\MeasurementProtocol\Dto\Parameter\ItemParameter;
+
+// Create service instance
+$ga4Service = new Service('MEASUREMENT_PROTOCOL_API_SECRET');
+$ga4Service->setMeasurementId('MEASUREMENT_ID');
+
+// Create base request
+$baseRequest = new BaseRequest();
+$baseRequest->setClientId('CLIENT_ID');
+
+// Create Invalid Event Data
+$addToCartEventData = new AddToCartEvent();
+$addToCartEventData
+    ->setValue(99.99)
+    ->setCurrency('SOME_INVALID_CURRENCY_CODE'); // invalid currency code
+
+// addItem
+$addToCartEventData->addItem(new ItemParameter([
+    'item_id' => 'ITEM_ID',
+    'item_name' => 'ITEM_NAME',
+    'price' => 99.99,
+    'quantity' => 1
+]));
+
+// Add event to base request (you can add up to 25 events to single request)
+$baseRequest->addEvent($addToCartEventData);
+
+// Instead of $ga4Service->send($baseRequest);
+// That way we can get response as stream in StreamResponse class body property
+$streamResponse = $ga4Service->sendStream($baseRequest);
+
+var_dump($debugResponse->getBody());
 
 ```
 

--- a/src/Dto/Response/BaseResponse.php
+++ b/src/Dto/Response/BaseResponse.php
@@ -72,6 +72,6 @@ class BaseResponse extends AbstractResponse
     public function hydrate($blueprint)
     {
         $this->setStatusCode($blueprint->getStatusCode());
-        $this->setBody($blueprint->getBody()->getContents());
+        $this->setBody($blueprint->getBody());
     }
 }

--- a/src/Dto/Response/StreamResponse.php
+++ b/src/Dto/Response/StreamResponse.php
@@ -7,9 +7,10 @@
 
 namespace Br33f\Ga4\MeasurementProtocol\Dto\Response;
 
+use GuzzleHttp\Psr7\Stream;
 use Psr\Http\Message\ResponseInterface;
 
-class BaseResponse extends AbstractResponse
+class StreamResponse extends AbstractResponse
 {
     /**
      * @var int|null
@@ -17,27 +18,9 @@ class BaseResponse extends AbstractResponse
     protected $statusCode;
 
     /**
-     * @var string
+     * @var Stream
      */
     protected $body;
-
-    /**
-     * @return int|null
-     */
-    public function getStatusCode(): ?int
-    {
-        return $this->statusCode;
-    }
-
-    /**
-     * @param int|null $statusCode
-     * @return BaseResponse
-     */
-    public function setStatusCode(?int $statusCode)
-    {
-        $this->statusCode = $statusCode;
-        return $this;
-    }
 
     /**
      * Get parsed body
@@ -49,18 +32,18 @@ class BaseResponse extends AbstractResponse
     }
 
     /**
-     * @return string
+     * @return Stream
      */
-    public function getBody(): string
+    public function getBody(): Stream
     {
         return $this->body;
     }
 
     /**
-     * @param string $body
-     * @return BaseResponse
+     * @param Stream $body
+     * @return StreamResponse
      */
-    public function setBody(string $body)
+    public function setBody(Stream $body)
     {
         $this->body = $body;
         return $this;
@@ -72,6 +55,24 @@ class BaseResponse extends AbstractResponse
     public function hydrate($blueprint)
     {
         $this->setStatusCode($blueprint->getStatusCode());
-        $this->setBody($blueprint->getBody()->getContents());
+        $this->setBody($blueprint->getBody());
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getStatusCode(): ?int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @param int|null $statusCode
+     * @return StreamResponse
+     */
+    public function setStatusCode(?int $statusCode)
+    {
+        $this->statusCode = $statusCode;
+        return $this;
     }
 }

--- a/tests/Ga4/MeasurementProtocol/Dto/Response/StreamResponseTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Response/StreamResponseTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 24.06.2021
+ * Time: 14:25
+ */
+
+namespace Tests\Ga4\MeasurementProtocol\Dto\Response;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Response\StreamResponse;
+use GuzzleHttp\Psr7\Response;
+use Tests\Common\BaseTestCase;
+
+class StreamResponseTest extends BaseTestCase
+{
+    /**
+     * @var StreamResponse
+     */
+    protected $baseResponse;
+
+    public function testDefaultConstructor()
+    {
+        $constructedStreamResponse = new StreamResponse();
+
+        $this->assertNotNull($constructedStreamResponse);
+    }
+
+    public function testBlueprintConstructor()
+    {
+        $response = new Response(200, [], '{"test_field": {"value": "123"}}');
+        $constructedStreamResponse = new StreamResponse($response);
+
+        $this->assertNotNull($constructedStreamResponse);
+        $this->assertEquals(200, $constructedStreamResponse->getStatusCode());
+        $this->assertEquals('{"test_field": {"value": "123"}}', $constructedStreamResponse->getBody());
+    }
+
+    public function testStatusCode()
+    {
+        $setStatusCode = 204;
+        $this->streamResponse->setStatusCode($setStatusCode);
+
+        $this->assertEquals(204, $this->streamResponse->getStatusCode());
+    }
+
+    public function testData()
+    {
+        $response = new Response(200, [], '{"test_field": {"value": "123"}}');
+        $this->streamResponse->setBody($response->getBody());
+
+        $this->assertEquals($response->getBody(), $this->streamResponse->getBody());
+        $this->assertEquals(json_decode($response->getBody(), true), $this->streamResponse->getData());
+    }
+
+    public function testBody()
+    {
+        $response = new Response(200, [], '{"test_field": {"value": "123"}}');
+        $this->streamResponse->setBody($response->getBody());
+
+        $this->assertEquals($response->getBody(), $this->streamResponse->getBody());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->streamResponse = new StreamResponse();
+    }
+}

--- a/tests/Ga4/MeasurementProtocol/ServiceTest.php
+++ b/tests/Ga4/MeasurementProtocol/ServiceTest.php
@@ -11,6 +11,7 @@ use Br33f\Ga4\MeasurementProtocol\Dto\Event\BaseEvent;
 use Br33f\Ga4\MeasurementProtocol\Dto\Request\BaseRequest;
 use Br33f\Ga4\MeasurementProtocol\Dto\Response\AbstractResponse;
 use Br33f\Ga4\MeasurementProtocol\Dto\Response\DebugResponse;
+use Br33f\Ga4\MeasurementProtocol\Dto\Response\StreamResponse;
 use Br33f\Ga4\MeasurementProtocol\Exception\MisconfigurationException;
 use Br33f\Ga4\MeasurementProtocol\HttpClient;
 use Br33f\Ga4\MeasurementProtocol\Service;
@@ -254,6 +255,30 @@ class ServiceTest extends BaseTestCase
 
         $this->expectException(MisconfigurationException::class);
         $testService->getQueryParameters();
+    }
+
+    public function testSendStream()
+    {
+        $mock = new MockHandler([
+            new Response(200)
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        $setApiSecret = $this->faker->word;
+        $setMeasurementId = $this->faker->bothify('**-########');
+        $sendService = new Service($setApiSecret, $setMeasurementId);
+        $sendService->getHttpClient()->setClient($mockClient);
+
+        $setClientId = $this->faker->asciify('********************.********************');
+        $sentRequest = new BaseRequest($setClientId);
+        $event = new BaseEvent($this->faker->word);
+        $sentRequest->addEvent($event);
+
+        $response = $sendService->sendStream($sentRequest);
+        $this->assertTrue($response instanceof StreamResponse);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Treat the response stream as string instead so the stream is not consumed.

Reason for this is that this allows to add a log middleware to the guzzle client. Without, the response body is no longer available for additional middleware.