### PR TITLE
Add support for `user_data`

### DIFF
--- a/src/Dto/Common/UserAddress.php
+++ b/src/Dto/Common/UserAddress.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 12.03.2024
+ * Time: 16:31
+ */
+
+namespace Br33f\Ga4\MeasurementProtocol\Dto\Common;
+
+class UserAddress extends UserData
+{
+    /**
+     * UserAddress constructor.
+     *
+     * @param UserDataItem[] $addressUserDataItemList
+     */
+    public function __construct(array $addressUserDataItemList = null)
+    {
+        parent::__construct($addressUserDataItemList);
+    }
+}

--- a/src/Dto/Common/UserAddress.php
+++ b/src/Dto/Common/UserAddress.php
@@ -12,31 +12,23 @@ use Br33f\Ga4\MeasurementProtocol\Dto\ExportableInterface;
 class UserAddress implements ExportableInterface
 {
     /**
-     * @var UserAddress[]|null
+     * @var UserDataItem[]|null
      */
     protected $userAddressItemList;
 
     /**
      * UserAddress constructor.
-     *
-     * @param UserAddress[]  $userAddressList
      */
-    public function __construct(array $userAddressItemList = null)
+    public function __construct(?array $userAddressItemList = null)
     {
         $this->userAddressItemList = $userAddressItemList;
     }
 
-    /**
-     * @param UserDataItem $userAddressItem
-     */
     public function addUserAddressItem(UserDataItem $userAddressItem)
     {
         $this->userAddressItemList[] = $userAddressItem;
     }
 
-    /**
-     * @return array
-     */
     public function export() : array
     {
         $userAddressExport = array_reduce($this->getUserAddressItemList(), function ($last, UserDataItem $userAddressItem) {
@@ -47,7 +39,7 @@ class UserAddress implements ExportableInterface
     }
 
     /**
-     * @return UserAddress[]|null
+     * @return UserDataItem[]|null
      */
     public function getUserAddressItemList() : ?array
     {
@@ -55,7 +47,7 @@ class UserAddress implements ExportableInterface
     }
 
     /**
-     * @param UserAddress[] $userAddressItemList
+     * @param UserDataItem[] $userAddressItemList
      */
     public function setUserAddressItemList(array $userAddressItemList)
     {

--- a/src/Dto/Common/UserAddress.php
+++ b/src/Dto/Common/UserAddress.php
@@ -7,15 +7,58 @@
 
 namespace Br33f\Ga4\MeasurementProtocol\Dto\Common;
 
-class UserAddress extends UserData
+use Br33f\Ga4\MeasurementProtocol\Dto\ExportableInterface;
+
+class UserAddress implements ExportableInterface
 {
+    /**
+     * @var UserAddress[]|null
+     */
+    protected $userAddressItemList;
+
     /**
      * UserAddress constructor.
      *
-     * @param UserDataItem[] $addressUserDataItemList
+     * @param UserAddress[]  $userAddressList
      */
-    public function __construct(array $addressUserDataItemList = null)
+    public function __construct(array $userAddressItemList = null)
     {
-        parent::__construct($addressUserDataItemList);
+        $this->userAddressItemList = $userAddressItemList;
+    }
+
+    /**
+     * @param UserDataItem $userAddressItem
+     */
+    public function addUserAddressItem(UserDataItem $userAddressItem)
+    {
+        $this->userAddressItemList[] = $userAddressItem;
+    }
+
+    /**
+     * @return array
+     */
+    public function export() : array
+    {
+        $userAddressExport = array_reduce($this->getUserAddressItemList(), function ($last, UserDataItem $userAddressItem) {
+            return array_merge($last, $userAddressItem->export());
+        }, []);
+
+        return $userAddressExport;
+    }
+
+    /**
+     * @return UserAddress[]|null
+     */
+    public function getUserAddressItemList() : ?array
+    {
+        return $this->userAddressItemList;
+    }
+
+    /**
+     * @param UserAddress[] $userAddressItemList
+     */
+    public function setUserAddressItemList(array $userAddressItemList)
+    {
+        $this->userAddressItemList = $userAddressItemList;
     }
 }

--- a/src/Dto/Common/UserData.php
+++ b/src/Dto/Common/UserData.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 12.03.2024
+ * Time: 16:31
+ */
+
+namespace Br33f\Ga4\MeasurementProtocol\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\ExportableInterface;
+
+class UserData implements ExportableInterface
+{
+    /**
+     * @var UserDataItem[]
+     */
+    protected $userDataItemList;
+
+    /**
+     * @var UserAddress[]|null
+     */
+    protected $userAddressList;
+
+    /**
+     * UserData constructor.
+     *
+     * @param UserDataItem[] $userDataItemList
+     * @param UserAddress[]  $userAddressList
+     */
+    public function __construct(array $userDataItemList = null, array $userAddressList = null)
+    {
+        $this->userDataItemList = $userDataItemList ?? [];
+        $this->userAddressList = $userAddressList;
+    }
+
+    /**
+     * @param UserDataItem $userDataItem
+     */
+    public function addUserDataItem(UserDataItem $userDataItem)
+    {
+        $this->userDataItemList[] = $userDataItem;
+    }
+
+    /**
+     * @param UserAddress $userAddress
+     */
+    public function addUserAddress(UserAddress $userAddress)
+    {
+        if ($this->getUserAddressList() === null) {
+            $this->setUserAddressList([]);
+        }
+
+        $this->userAddressList[] = $userAddress;
+    }
+
+    /**
+     * @return array
+     */
+    public function export() : array
+    {
+        $userDataExport = array_reduce($this->getUserDataItemList(), function ($last, UserDataItem $userDataItem) {
+            return array_merge($last, $userDataItem->export());
+        }, []);
+
+        if ($this->getUserAddressList() !== null) {
+            $userDataExport['address'] = array_map(function (UserAddress $userAddress) {
+                return $userAddress->export();
+            }, $this->getUserAddressList());
+        }
+
+        return $userDataExport;
+    }
+
+    /**
+     * @return UserDataItem[]
+     */
+    public function getUserDataItemList() : array
+    {
+        return $this->userDataItemList;
+    }
+
+    /**
+     * @param UserDataItem[] $userDataItemList
+     */
+    public function setUserDataItemList(array $userDataItemList)
+    {
+        $this->userDataItemList = $userDataItemList;
+    }
+
+    /**
+     * @return UserAddress[]|null
+     */
+    public function getUserAddressList() : ?array
+    {
+        return $this->userAddressList;
+    }
+
+    /**
+     * @param UserAddress[] $userAddressList
+     */
+    public function setUserAddressList(array $userAddressList)
+    {
+        $this->userAddressList = $userAddressList;
+    }
+}

--- a/src/Dto/Common/UserDataItem.php
+++ b/src/Dto/Common/UserDataItem.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 12.03.2024
+ * Time: 16:31
+ */
+
+namespace Br33f\Ga4\MeasurementProtocol\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\ExportableInterface;
+
+class UserDataItem implements ExportableInterface
+{
+    /**
+     * User property name
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * User property value
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * UserDataItem constructor.
+     *
+     * @param string|null $name
+     * @param mixed $value
+     */
+    public function __construct(?string $name = null, $value = null)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    public function export() : array
+    {
+        $value = $this->getValue() instanceof ExportableInterface
+            ? $this->getValue()->export()
+            : $this->getValue();
+
+        return [
+            $this->getName() => $value,
+        ];
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName() : ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     */
+    public function setName(?string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Dto/Request/BaseRequest.php
+++ b/src/Dto/Request/BaseRequest.php
@@ -8,6 +8,8 @@
 namespace Br33f\Ga4\MeasurementProtocol\Dto\Request;
 
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\EventCollection;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserData;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserDataItem;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperties;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperty;
 use Br33f\Ga4\MeasurementProtocol\Dto\Event\AbstractEvent;
@@ -49,6 +51,13 @@ class BaseRequest extends AbstractRequest
      * @var UserProperties
      */
     protected $userProperties = null;
+
+    /**
+     * The user data for the measurement.
+     * Not required
+     * @var UserData
+     */
+    protected $userData = null;
 
     /**
      * If set true - indicates that events should not be use for personalized ads.
@@ -120,6 +129,39 @@ class BaseRequest extends AbstractRequest
         return $this;
     }
 
+
+    /**
+     * @param UserData $userProperty
+     * @return BaseRequest
+     */
+    public function addUserDataItem(UserDataItem $userDataItem)
+    {
+        if ($this->getUserData() === null) {
+            $this->setUserData(new UserData());
+        }
+
+        $this->getUserData()->addUserDataItem($userDataItem);
+        return $this;
+    }
+
+    /**
+     * @return UserProperties|null
+     */
+    public function getUserData(): ?UserData
+    {
+        return $this->userData;
+    }
+
+    /**
+     * @param UserData|null $userData
+     * @return BaseRequest
+     */
+    public function setUserData(?UserData $userData)
+    {
+        $this->userData = $userData;
+        return $this;
+    }
+
     /**
      * @param AbstractEvent $event
      * @return BaseRequest
@@ -170,6 +212,10 @@ class BaseRequest extends AbstractRequest
 
         if ($this->getUserProperties() !== null) {
             $exportBaseRequest['user_properties'] = $this->getUserProperties()->export();
+        }
+
+        if ($this->getUserData() !== null) {
+            $exportBaseRequest['user_data'] = $this->getUserData()->export();
         }
 
         return $exportBaseRequest;

--- a/tests/Dto/Common/UserAddressTest.php
+++ b/tests/Dto/Common/UserAddressTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 20.04.2024
+ * Time: 12:09
+ */
+
+namespace Tests\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserAddress;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserDataItem;
+use Tests\Common\BaseTestCase;
+
+class UserAddressTest extends BaseTestCase
+{
+    /**
+     * @var UserAddress
+     */
+    protected $userAddress;
+
+    public function testDefaultConstructor()
+    {
+        $constructedUserAddress = new UserAddress();
+
+        $this->assertEquals(null, $constructedUserAddress->getUserAddressItemList());
+    }
+
+    public function testConstructor()
+    {
+        $setUserDataItemList = [
+            new UserDataItem(),
+            new UserDataItem()
+        ];
+        $constructedUserAddress = new UserAddress($setUserDataItemList);
+
+        $this->assertEquals($setUserDataItemList, $constructedUserAddress->getUserAddressItemList());
+    }
+
+    public function testAddUserAddressItem()
+    {
+        $userDataItem = new UserDataItem($this->faker->word, $this->faker->word);
+
+        $this->userAddress->addUserAddressItem($userDataItem);
+
+        $this->assertEquals([$userDataItem], $this->userAddress->getUserAddressItemList());
+    }
+
+    public function testSetUserAddressItemList()
+    {
+        $userAddressDatum1 = new UserDataItem($this->faker->word, $this->faker->word);
+        $userAddressDatum2 = new UserDataItem($this->faker->word, $this->faker->word);
+
+        $this->userAddress->setUserAddressItemList([$userAddressDatum1, $userAddressDatum2]);
+
+        $this->assertEquals([$userAddressDatum1, $userAddressDatum2], $this->userAddress->getUserAddressItemList());
+    }
+
+    protected function setUp(): void
+    {
+        $this->userAddress = new UserAddress();
+    }
+}

--- a/tests/Ga4/MeasurementProtocol/Dto/Common/UserAddressTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Common/UserAddressTest.php
@@ -5,7 +5,7 @@
  * Time: 12:09
  */
 
-namespace Tests\Dto\Common;
+namespace Tests\Ga4\MeasurementProtocol\Dto\Common;
 
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserAddress;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserDataItem;

--- a/tests/Ga4/MeasurementProtocol/Dto/Common/UserDataItemTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Common/UserDataItemTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 12.03.2024
+ * Time: 16:31
+ */
+
+namespace Ga4\MeasurementProtocol\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserDataItem;
+use Tests\Common\BaseTestCase;
+
+class UserDataItemTest extends BaseTestCase
+{
+    /**
+     * @var UserDataItem
+     */
+    protected $userDataItem;
+
+    public function testDefaultConstructor()
+    {
+        $constructedUserDataItem = new UserDataItem();
+
+        $this->assertEquals(null, $constructedUserDataItem->getName());
+        $this->assertEquals(null, $constructedUserDataItem->getValue());
+    }
+
+    public function testParametrizedConstructor()
+    {
+        $setName = $this->faker->word;
+        $setValue = $this->faker->word;
+        $constructedUserDataItem = new UserDataItem($setName, $setValue);
+
+        $this->assertEquals($setName, $constructedUserDataItem->getName());
+        $this->assertEquals($setValue, $constructedUserDataItem->getValue());
+    }
+
+    public function testName()
+    {
+        $setName = $this->faker->word;
+        $this->userDataItem->setName($setName);
+
+        $this->assertEquals($setName, $this->userDataItem->getName());
+    }
+
+    public function testValue()
+    {
+        $setValue = $this->faker->word;
+        $this->userDataItem->setValue($setValue);
+
+        $this->assertEquals($setValue, $this->userDataItem->getValue());
+    }
+
+    public function testExportNested()
+    {
+        $rootName = 'root';
+        $nestedName = 'nested';
+        $nestedValue = 'nvalue';
+
+        $nestedUserDataItem = new UserDataItem($nestedName, $nestedValue);
+        $userDataItem = new UserDataItem($rootName, $nestedUserDataItem);
+
+        $this->assertEquals([$rootName => [$nestedName => $nestedValue]], $userDataItem->export());
+    }
+
+    public function testExportEmpty()
+    {
+        $emptyUserDataItem = new UserDataItem();
+
+        $this->assertEquals([null => null], $emptyUserDataItem->export());
+    }
+
+    public function testExport()
+    {
+        $setName = $this->faker->word;
+        $setValue = $this->faker->word;
+        $emptyUserDataItem = new UserDataItem($setName, $setValue);
+
+        $this->assertEquals([$setName => $setValue], $emptyUserDataItem->export());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userDataItem = new UserDataItem();
+    }
+}

--- a/tests/Ga4/MeasurementProtocol/Dto/Common/UserDataTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Common/UserDataTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * User: Damian Zamojski (br33f)
+ * Date: 12.03.2024
+ * Time: 16:31
+ */
+
+namespace Ga4\MeasurementProtocol\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserAddress;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserData;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserDataItem;
+use Tests\Common\BaseTestCase;
+
+class UserDataTest extends BaseTestCase
+{
+    /**
+     * @var UserData
+     */
+    protected $userData;
+
+    public function testDefaultConstructor()
+    {
+        $constructedUserData = new UserData();
+
+        $this->assertEquals([], $constructedUserData->getUserDataItemList());
+    }
+
+    public function testConstructor()
+    {
+        $setUserDataItemList = [
+            new UserDataItem(),
+            new UserDataItem()
+        ];
+        $constructedUserData = new UserData($setUserDataItemList);
+
+        $this->assertEquals($setUserDataItemList, $constructedUserData->getUserDataItemList());
+    }
+
+    public function testUserDataList()
+    {
+        $setUserDataItemList = [
+            new UserDataItem($this->faker->word, $this->faker->word),
+            new UserDataItem($this->faker->word, $this->faker->word),
+            new UserDataItem($this->faker->word, $this->faker->word)
+        ];
+
+        $this->userData->setUserDataItemList($setUserDataItemList);
+
+        $this->assertEquals($setUserDataItemList, $this->userData->getUserDataItemList());
+    }
+
+    public function testUserDataAdd()
+    {
+        $this->userData->setUserDataItemList([]);
+
+        $addUserDataItem = new UserDataItem($this->faker->word, $this->faker->word);
+        $this->userData->addUserDataItem($addUserDataItem);
+
+        $this->assertEquals(1, count($this->userData->getUserDataItemList()));
+        $this->assertEquals($addUserDataItem, $this->userData->getUserDataItemList()[0]);
+    }
+
+    public function testExport()
+    {
+        $setUserDataItem = [
+            new UserDataItem($this->faker->word, $this->faker->word),
+            new UserDataItem($this->faker->word, $this->faker->word),
+            new UserDataItem($this->faker->word, $this->faker->word)
+        ];
+
+        $this->userData->setUserDataItemList($setUserDataItem);
+
+        $this->assertEquals([
+            $setUserDataItem[0]->getName() => $setUserDataItem[0]->getValue(),
+            $setUserDataItem[1]->getName() => $setUserDataItem[1]->getValue(),
+            $setUserDataItem[2]->getName() => $setUserDataItem[2]->getValue(),
+        ], $this->userData->export());
+    }
+
+    public function testExportAddress()
+    {
+        $userAddressDatum1 = new UserDataItem($this->faker->word, $this->faker->word);
+        $userAddressDatum2 = new UserDataItem($this->faker->word, $this->faker->word);
+        $userAddress = new UserAddress([$userAddressDatum1, $userAddressDatum2]);
+        $this->userData->setUserAddressList([$userAddress]);
+
+        $this->assertEquals([
+            'address' => [
+                [
+                    $userAddressDatum1->getName() => $userAddressDatum1->getValue(),
+                    $userAddressDatum2->getName() => $userAddressDatum2->getValue(),
+                ],
+            ]
+        ], $this->userData->export());
+    }
+
+    protected function setUp(): void
+    {
+        $this->userData = new UserData();
+    }
+}

--- a/tests/Ga4/MeasurementProtocol/Dto/Common/UserDataTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Common/UserDataTest.php
@@ -95,6 +95,24 @@ class UserDataTest extends BaseTestCase
         ], $this->userData->export());
     }
 
+    public function testAddUserAddress()
+    {
+        $userAddressDatum1 = new UserDataItem($this->faker->word, $this->faker->word);
+        $userAddressDatum2 = new UserDataItem($this->faker->word, $this->faker->word);
+        $userAddress = new UserAddress([$userAddressDatum1, $userAddressDatum2]);
+
+        $this->userData->addUserAddress($userAddress);
+
+        $this->assertEquals([
+            'address' => [
+                [
+                    $userAddressDatum1->getName() => $userAddressDatum1->getValue(),
+                    $userAddressDatum2->getName() => $userAddressDatum2->getValue(),
+                ],
+            ]
+        ], $this->userData->export());
+    }
+
     protected function setUp(): void
     {
         $this->userData = new UserData();

--- a/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
@@ -209,12 +209,16 @@ class BaseRequestTest extends BaseTestCase
         $setUserProperties = new UserProperties();
         $exportBaseRequest->setUserProperties($setUserProperties);
 
+        $constructedUserData = new UserData();
+        $exportBaseRequest->setUserData($constructedUserData);
+
         $this->assertEquals([
             'client_id' => $setClientId,
             'events' => $setEventCollection->export(),
             'user_id' => $setUserId,
             'timestamp_micros' => $setTimestampMicros,
-            'user_properties' => $setUserProperties->export()
+            'user_properties' => $setUserProperties->export(),
+            'user_data' => $constructedUserData->export(),
         ], $exportBaseRequest->export());
     }
 

--- a/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
@@ -8,6 +8,8 @@
 namespace Tests\Ga4\MeasurementProtocol\Dto\Request;
 
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\EventCollection;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserData;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserDataItem;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperties;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperty;
 use Br33f\Ga4\MeasurementProtocol\Dto\Event\BaseEvent;
@@ -88,6 +90,23 @@ class BaseRequestTest extends BaseTestCase
 
         $this->assertEquals(1, count($this->baseRequest->getUserProperties()->getUserPropertiesList()));
         $this->assertEquals($addUserProperty, $this->baseRequest->getUserProperties()->getUserPropertiesList()[0]);
+    }
+
+    public function testUserData()
+    {
+        $setUserData = new UserData();
+        $this->baseRequest->setUserData($setUserData);
+
+        $this->assertEquals($setUserData, $this->baseRequest->getUserData());
+    }
+
+    public function testAddUserDataItem()
+    {
+        $addUserDataItem = new UserDataItem($this->faker->word, $this->faker->word);
+        $this->baseRequest->addUserDataItem($addUserDataItem);
+
+        $this->assertEquals(1, count($this->baseRequest->getUserData()->getUserDataItemList()));
+        $this->assertEquals($addUserDataItem, $this->baseRequest->getUserData()->getUserDataItemList()[0]);
     }
 
     public function testEvents()


### PR DESCRIPTION
According to documentation about [providing data with user-id](https://developers.google.com/analytics/devguides/collection/ga4/uid-data) there is also a `user_data` top level element in the API data.

This adds some basic classes/structures to add that data to the post body.