### PR TITLE
Add support for consent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,40 @@ $baseRequest = new BaseRequest();
 $baseRequest->setAppInstanceId('APP_INSTANCE_ID'); // instead of setClientId(...)
 ```
 
+### Consent mode v2
+
+This library supports consent mode v2 : [see documentation](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_consent)
+
+```php
+use Br33f\Ga4\MeasurementProtocol\Dto\Request\BaseRequest;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\ConsentProperty;
+use Br33f\Ga4\MeasurementProtocol\Enum\ConsentCode;
+
+// Create consent property with :
+// - ad_user_data = GRANTED
+// - ad_personalization = DENIED
+$consent = new ConsentProperty();
+$consent->setAdUserData(ConsentCode::GRANTED);
+$consent->setAdPersonalization(ConsentCode::DENIED);
+
+// Create base request
+$baseRequest = new BaseRequest();
+$baseRequest->setConsent($consent);
+```
+
+This mode replaces now obsolete / deprecated `non_personalized_ads` :
+
+```php
+$baseRequest = new BaseRequest();
+$baseRequest->setNonPersonalizedAds(true);
+
+// Is replaced by :
+
+$consent = new ConsentProperty();
+$consent->setAdPersonalization(ConsentCode::GRANTED);
+$baseRequest->setConsent($consent);
+```
+
 
 ## Debug event data and requests
 Debuging event data is possible by sending them to debug endpoint (Measurement Protocol Validation Server), since default endpoint for Google Analytics 4 Measurement Protocol does not return any HTTP error codes or messages. In order to validate event one should use `sendDebug($request)` method instead of `send($request)`.

--- a/src/Dto/Common/ConsentProperty.php
+++ b/src/Dto/Common/ConsentProperty.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * User: Alexis POUPELIN (AlexisPPLIN)
+ * Date: 08.04.2024
+ * Time: 11:00
+ */
+
+namespace Br33f\Ga4\MeasurementProtocol\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\ExportableInterface;
+use Br33f\Ga4\MeasurementProtocol\Enum\ConsentCode;
+
+class ConsentProperty implements ExportableInterface
+{
+    /**
+     * Sets consent for sending user data from the request's events and user properties to Google for advertising purposes.
+     * @var ConsentCode
+     */
+    protected $ad_user_data;
+
+    /**
+     * Sets consent for personalized advertising for the user.
+     * @var ConsentCode
+     */
+    protected $ad_personalization;
+
+    /**
+     * ConsentProperty constructor
+     * @param ConsentCode|null $ad_user_data
+     * @param ConsentCode|null $ad_personalization
+     */
+    public function __construct(?ConsentCode $ad_user_data = null, ?ConsentCode $ad_personalization = null)
+    {
+        $this->ad_user_data = $ad_user_data;
+        $this->ad_personalization = $ad_personalization;
+    }
+
+    public function export() : array
+    {
+        $result = [];
+
+        if (isset($this->ad_user_data)) {
+            $result['ad_user_data'] = $this->ad_user_data;
+        }
+
+        if (isset($this->ad_personalization)) {
+            $result['ad_personalization'] = $this->ad_personalization;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return ConsentCode|null
+     */
+    public function getAdUserData() : ?ConsentCode
+    {
+        return $this->ad_user_data;
+    }
+
+    /**
+     * @param ConsentCode|null $ad_user_data
+     */
+    public function setAdUserData(?ConsentCode $ad_user_data) : void
+    {
+        $this->ad_user_data = $ad_user_data;
+    }
+
+    /**
+     * @return ConsentCode|null
+     */
+    public function getAdPersonalization() : ?ConsentCode
+    {
+        return $this->ad_personalization;
+    }
+
+    /**
+     * @param ConsentCode|null $ad_personalization
+     */
+    public function setAdPersonalization(?ConsentCode $ad_personalization) : void
+    {
+        $this->ad_personalization = $ad_personalization;
+    }
+}

--- a/src/Dto/Common/ConsentProperty.php
+++ b/src/Dto/Common/ConsentProperty.php
@@ -14,22 +14,25 @@ class ConsentProperty implements ExportableInterface
 {
     /**
      * Sets consent for sending user data from the request's events and user properties to Google for advertising purposes.
-     * @var ConsentCode
+     * Must be either {@see ConsentCode::GRANTED} or {@see ConsentCode::DENIED}
+     * @var string
      */
     protected $ad_user_data;
 
     /**
      * Sets consent for personalized advertising for the user.
-     * @var ConsentCode
+     * Must be either {@see ConsentCode::GRANTED} or {@see ConsentCode::DENIED}
+     * @var string
      */
     protected $ad_personalization;
 
     /**
      * ConsentProperty constructor
-     * @param ConsentCode|null $ad_user_data
-     * @param ConsentCode|null $ad_personalization
+     * Each parameters must be either {@see ConsentCode::GRANTED} or {@see ConsentCode::DENIED}
+     * @param string|null $ad_user_data 
+     * @param string|null $ad_personalization
      */
-    public function __construct(?ConsentCode $ad_user_data = null, ?ConsentCode $ad_personalization = null)
+    public function __construct(?string $ad_user_data = null, ?string $ad_personalization = null)
     {
         $this->ad_user_data = $ad_user_data;
         $this->ad_personalization = $ad_personalization;
@@ -51,33 +54,35 @@ class ConsentProperty implements ExportableInterface
     }
 
     /**
-     * @return ConsentCode|null
+     * @return string|null
      */
-    public function getAdUserData() : ?ConsentCode
+    public function getAdUserData() : ?string
     {
         return $this->ad_user_data;
     }
 
     /**
-     * @param ConsentCode|null $ad_user_data
+     * Must be either {@see ConsentCode::GRANTED} or {@see ConsentCode::DENIED}
+     * @param string|null $ad_user_data
      */
-    public function setAdUserData(?ConsentCode $ad_user_data) : void
+    public function setAdUserData(?string $ad_user_data) : void
     {
         $this->ad_user_data = $ad_user_data;
     }
 
     /**
-     * @return ConsentCode|null
+     * @return string|null
      */
-    public function getAdPersonalization() : ?ConsentCode
+    public function getAdPersonalization() : ?string
     {
         return $this->ad_personalization;
     }
 
     /**
-     * @param ConsentCode|null $ad_personalization
+     * Must be either {@see ConsentCode::GRANTED} or {@see ConsentCode::DENIED}
+     * @param string|null $ad_personalization
      */
-    public function setAdPersonalization(?ConsentCode $ad_personalization) : void
+    public function setAdPersonalization(?string $ad_personalization) : void
     {
         $this->ad_personalization = $ad_personalization;
     }

--- a/src/Dto/Request/BaseRequest.php
+++ b/src/Dto/Request/BaseRequest.php
@@ -182,9 +182,10 @@ class BaseRequest extends AbstractRequest
         $exportBaseRequest = array_filter([
             'client_id' => $this->getClientId(),
             'app_instance_id' => $this->getAppInstanceId(),
-            'non_personalized_ads' => $this->isNonPersonalizedAds(),
             'events' => $this->getEvents()->export(),
         ]);
+
+        $exportBaseRequest['non_personalized_ads'] = $this->isNonPersonalizedAds();
 
         if ($this->getUserId() !== null) {
             $exportBaseRequest['user_id'] = $this->getUserId();

--- a/src/Dto/Request/BaseRequest.php
+++ b/src/Dto/Request/BaseRequest.php
@@ -53,10 +53,10 @@ class BaseRequest extends AbstractRequest
 
     /**
      * If set true - indicates that events should not be use for personalized ads.
-     * Default false
-     * @var bool
+     * Not required
+     * @var ?bool
      */
-    protected $nonPersonalizedAds = false;
+    protected $nonPersonalizedAds = null;
 
     /**
      * Sets the consent settings for the request.
@@ -185,7 +185,9 @@ class BaseRequest extends AbstractRequest
             'events' => $this->getEvents()->export(),
         ]);
 
-        $exportBaseRequest['non_personalized_ads'] = $this->isNonPersonalizedAds();
+        if ($this->getNonPersonalizedAds() !== null) {
+            $exportBaseRequest['non_personalized_ads'] = $this->isNonPersonalizedAds();
+        }
 
         if ($this->getUserId() !== null) {
             $exportBaseRequest['user_id'] = $this->getUserId();
@@ -246,6 +248,19 @@ class BaseRequest extends AbstractRequest
      * @return bool
      */
     public function isNonPersonalizedAds(): bool
+    {
+        $nonPersonalizedAds = $this->getNonPersonalizedAds();
+        if (!isset($nonPersonalizedAds)) {
+            return false;
+        }
+
+        return $this->nonPersonalizedAds;
+    }
+
+    /**
+     * @return ?bool
+     */
+    public function getNonPersonalizedAds() : ?bool
     {
         return $this->nonPersonalizedAds;
     }

--- a/src/Dto/Request/BaseRequest.php
+++ b/src/Dto/Request/BaseRequest.php
@@ -10,6 +10,7 @@ namespace Br33f\Ga4\MeasurementProtocol\Dto\Request;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\EventCollection;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperties;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperty;
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\ConsentProperty;
 use Br33f\Ga4\MeasurementProtocol\Dto\Event\AbstractEvent;
 use Br33f\Ga4\MeasurementProtocol\Enum\ErrorCode;
 use Br33f\Ga4\MeasurementProtocol\Exception\ValidationException;
@@ -57,6 +58,13 @@ class BaseRequest extends AbstractRequest
      */
     protected $nonPersonalizedAds = false;
 
+    /**
+     * Sets the consent settings for the request.
+     * Replaces non_personalized_ads
+     * Not required
+     * @var ConsentProperty
+     */
+    protected $consent = null;
 
     /**
      * Collection of event items. Maximum 25 events.
@@ -121,6 +129,24 @@ class BaseRequest extends AbstractRequest
     }
 
     /**
+     * @return ConsentProperty|null
+     */
+    public function getConsent() : ?ConsentProperty
+    {
+        return $this->consent;
+    }
+
+    /**
+     * @param ConsentProperty|null $consent
+     * @return BaseRequest
+     */
+    public function setConsent(?ConsentProperty $consent) : self
+    {
+        $this->consent = $consent;
+        return $this;
+    }
+
+    /**
      * @param AbstractEvent $event
      * @return BaseRequest
      */
@@ -170,6 +196,10 @@ class BaseRequest extends AbstractRequest
 
         if ($this->getUserProperties() !== null) {
             $exportBaseRequest['user_properties'] = $this->getUserProperties()->export();
+        }
+
+        if ($this->getConsent() !== null) {
+            $exportBaseRequest['consent'] = $this->getConsent()->export();
         }
 
         return $exportBaseRequest;

--- a/src/Enum/ConsentCode.php
+++ b/src/Enum/ConsentCode.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * User: Alexis POUPELIN (AlexisPPLIN)
+ * Date: 08.04.2024
+ * Time: 11:00
+ */
+
+namespace Br33f\Ga4\MeasurementProtocol\Enum;
+
+
+class ConsentCode 
+{
+    const GRANTED = 'GRANTED';
+    const DENIED = 'DENIED';
+}

--- a/tests/Ga4/MeasurementProtocol/Dto/Common/ConsentPropertyTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Common/ConsentPropertyTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * User: Alexis POUPELIN (AlexisPPLIN)
+ * Date: 08.04.2024
+ * Time: 11:00
+ */
+
+namespace Tests\Ga4\MeasurementProtocol\Dto\Common;
+
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\ConsentProperty;
+use Br33f\Ga4\MeasurementProtocol\Enum\ConsentCode;
+use Tests\Common\BaseTestCase;
+
+class ConsentPropertyTest extends BaseTestCase
+{
+    /**
+     * @var ConsentProperty
+     */
+    protected $consentProperty;
+
+    public function testDefaultConstructor()
+    {
+        $constructedConsentProperty = new ConsentProperty();
+
+        $this->assertNull($constructedConsentProperty->getAdUserData());
+        $this->assertNull($constructedConsentProperty->getAdPersonalization());
+    }
+
+    public function testParametrizedConstructor()
+    {
+        $ad_user_data = ConsentCode::DENIED;
+        $ad_personalization = ConsentCode::GRANTED;
+        $constructedConsentProperty = new ConsentProperty($ad_user_data, $ad_personalization);
+
+        $this->assertEquals($ad_user_data, $constructedConsentProperty->getAdUserData());
+        $this->assertEquals($ad_personalization, $constructedConsentProperty->getAdPersonalization());
+    }
+
+    public function testAdUserData()
+    {
+        $ad_user_data = ConsentCode::DENIED;
+        $this->consentProperty->setAdUserData($ad_user_data);
+
+        $this->assertEquals($ad_user_data, $this->consentProperty->getAdUserData());
+    }
+
+    public function testAdPersonalization()
+    {
+        $ad_personalization = ConsentCode::GRANTED;
+        $this->consentProperty->setAdPersonalization($ad_personalization);
+
+        $this->assertEquals($ad_personalization, $this->consentProperty->getAdPersonalization());
+    }
+
+    public function testExportEmpty()
+    {
+        $emptyConsentProperty = new ConsentProperty();
+
+        $this->assertEquals([], $emptyConsentProperty->export());
+    }
+
+    public function testPartialExport()
+    {
+        $ad_user_data = ConsentCode::DENIED;
+        $ad_personalization = null;
+        $constructedConsentProperty = new ConsentProperty($ad_user_data, $ad_personalization);
+
+        $this->assertEquals(['ad_user_data' => 'DENIED'], $constructedConsentProperty->export());
+    }
+
+    public function testExport()
+    {
+        $ad_user_data = ConsentCode::DENIED;
+        $ad_personalization = ConsentCode::GRANTED;
+        $constructedConsentProperty = new ConsentProperty($ad_user_data, $ad_personalization);
+
+        $this->assertEquals(['ad_user_data' => 'DENIED', 'ad_personalization' => 'GRANTED'], $constructedConsentProperty->export());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->consentProperty = new ConsentProperty();
+    }
+}

--- a/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
@@ -7,12 +7,14 @@
 
 namespace Tests\Ga4\MeasurementProtocol\Dto\Request;
 
+use Br33f\Ga4\MeasurementProtocol\Dto\Common\ConsentProperty;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\EventCollection;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperties;
 use Br33f\Ga4\MeasurementProtocol\Dto\Common\UserProperty;
 use Br33f\Ga4\MeasurementProtocol\Dto\Event\BaseEvent;
 use Br33f\Ga4\MeasurementProtocol\Dto\Parameter\BaseParameter;
 use Br33f\Ga4\MeasurementProtocol\Dto\Request\BaseRequest;
+use Br33f\Ga4\MeasurementProtocol\Enum\ConsentCode;
 use Br33f\Ga4\MeasurementProtocol\Enum\ErrorCode;
 use Tests\Common\BaseTestCase;
 
@@ -88,6 +90,18 @@ class BaseRequestTest extends BaseTestCase
 
         $this->assertEquals(1, count($this->baseRequest->getUserProperties()->getUserPropertiesList()));
         $this->assertEquals($addUserProperty, $this->baseRequest->getUserProperties()->getUserPropertiesList()[0]);
+    }
+
+    public function testConsent()
+    {
+        $consent = new ConsentProperty();
+        $consent->setAdUserData(ConsentCode::GRANTED);
+        $consent->setAdPersonalization(ConsentCode::DENIED);
+        $this->baseRequest->setConsent($consent);
+
+        $this->assertNotNull($this->baseRequest->getConsent());
+        $this->assertEquals(ConsentCode::GRANTED, $this->baseRequest->getConsent()->getAdUserData());
+        $this->assertEquals(ConsentCode::DENIED, $this->baseRequest->getConsent()->getAdPersonalization());
     }
 
     public function testEvents()
@@ -190,12 +204,18 @@ class BaseRequestTest extends BaseTestCase
         $setUserProperties = new UserProperties();
         $exportBaseRequest->setUserProperties($setUserProperties);
 
+        $consent = new ConsentProperty();
+        $consent->setAdUserData(ConsentCode::GRANTED);
+        $consent->setAdPersonalization(ConsentCode::DENIED);
+        $exportBaseRequest->setConsent($consent);
+
         $this->assertEquals([
             'client_id' => $setClientId,
             'events' => $setEventCollection->export(),
             'user_id' => $setUserId,
             'timestamp_micros' => $setTimestampMicros,
-            'user_properties' => $setUserProperties->export()
+            'user_properties' => $setUserProperties->export(),
+            'consent' => $consent->export()
         ], $exportBaseRequest->export());
     }
 

--- a/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
@@ -204,6 +204,8 @@ class BaseRequestTest extends BaseTestCase
         $setUserProperties = new UserProperties();
         $exportBaseRequest->setUserProperties($setUserProperties);
 
+        $exportBaseRequest->setNonPersonalizedAds(false);
+
         $consent = new ConsentProperty();
         $consent->setAdUserData(ConsentCode::GRANTED);
         $consent->setAdPersonalization(ConsentCode::DENIED);
@@ -214,6 +216,7 @@ class BaseRequestTest extends BaseTestCase
             'events' => $setEventCollection->export(),
             'user_id' => $setUserId,
             'timestamp_micros' => $setTimestampMicros,
+            'non_personalized_ads' => false,
             'user_properties' => $setUserProperties->export(),
             'consent' => $consent->export()
         ], $exportBaseRequest->export());

--- a/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
@@ -181,6 +181,7 @@ class BaseRequestTest extends BaseTestCase
 
         $this->assertEquals([
             'client_id' => $setClientId,
+            'non_personalized_ads' => false,
             'events' => $setEventCollection->export(),
         ], $exportBaseRequest->export());
     }
@@ -204,7 +205,7 @@ class BaseRequestTest extends BaseTestCase
         $setUserProperties = new UserProperties();
         $exportBaseRequest->setUserProperties($setUserProperties);
 
-        $exportBaseRequest->setNonPersonalizedAds(false);
+        $exportBaseRequest->setNonPersonalizedAds(true);
 
         $consent = new ConsentProperty();
         $consent->setAdUserData(ConsentCode::GRANTED);
@@ -216,7 +217,7 @@ class BaseRequestTest extends BaseTestCase
             'events' => $setEventCollection->export(),
             'user_id' => $setUserId,
             'timestamp_micros' => $setTimestampMicros,
-            'non_personalized_ads' => false,
+            'non_personalized_ads' => true,
             'user_properties' => $setUserProperties->export(),
             'consent' => $consent->export()
         ], $exportBaseRequest->export());

--- a/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
+++ b/tests/Ga4/MeasurementProtocol/Dto/Request/BaseRequestTest.php
@@ -68,6 +68,8 @@ class BaseRequestTest extends BaseTestCase
 
     public function testNonPersonalizedAds()
     {
+        $this->assertEquals(null, $this->baseRequest->isNonPersonalizedAds());
+
         $this->baseRequest->setNonPersonalizedAds(true);
         $this->assertEquals(true, $this->baseRequest->isNonPersonalizedAds());
 
@@ -181,7 +183,6 @@ class BaseRequestTest extends BaseTestCase
 
         $this->assertEquals([
             'client_id' => $setClientId,
-            'non_personalized_ads' => false,
             'events' => $setEventCollection->export(),
         ], $exportBaseRequest->export());
     }


### PR DESCRIPTION
Hi !

## New features

- Support for [consent parameter](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_consent) in BaseRequest.
- Documentation how to use this new mode in `README.md`
- Added unit tests for consent parameter.

## Bug fixes :bug: 

- In `BaseRequest`, when setting `nonPersonalizedAds` to `false` nothing was sent to the mesurement API.
  > User consent for `non_personalized_ads` was not updated when refused
- Updated unit test to check `non_personalized_ads`

Have a nice day :smile: 